### PR TITLE
fix: updated gitea client and updated ouath2 creation function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "9.0.6",
         "@kubernetes/client-node": "0.12.3",
-        "@redkubes/gitea-client-node": "1.16.6",
+        "@redkubes/gitea-client-node": "1.19.1",
         "@redkubes/harbor-client-node": "^2.2.1",
         "@redkubes/keycloak-client-node": "^15.0.0",
         "async-retry": "1.3.1",
@@ -1252,9 +1252,9 @@
       }
     },
     "node_modules/@redkubes/gitea-client-node": {
-      "version": "1.16.6",
-      "resolved": "https://npm.pkg.github.com/download/@redkubes/gitea-client-node/1.16.6/2e474dc8d2f9c7b4e660603d5dafa4b5386363a0890c9e717ddb727dc1803cb7",
-      "integrity": "sha512-BGBMaSgwj3Wg1ppo8auonEAXZ9msk/zRGCoJYNz8DE3epuoLq2CYwJTBqQKBIXH+vPamom6CLFS8RCl8SGSKeQ==",
+      "version": "1.19.1",
+      "resolved": "https://npm.pkg.github.com/download/@redkubes/gitea-client-node/1.19.1/91f32e7ba2fd5919be4100f9697ba4947acbb44e",
+      "integrity": "sha512-qb+eLNOK8vSM/wctqV0WVBYnN0l7u9fu/F0jwL5X7sLGEFjSgOb+i5E8h1VoqnvNH1fLJ8M1OHQ/RLbG0cMbdQ==",
       "license": "Unlicense",
       "dependencies": {
         "bluebird": "^3.5.0",
@@ -13809,9 +13809,9 @@
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
     "@redkubes/gitea-client-node": {
-      "version": "1.16.6",
-      "resolved": "https://npm.pkg.github.com/download/@redkubes/gitea-client-node/1.16.6/2e474dc8d2f9c7b4e660603d5dafa4b5386363a0890c9e717ddb727dc1803cb7",
-      "integrity": "sha512-BGBMaSgwj3Wg1ppo8auonEAXZ9msk/zRGCoJYNz8DE3epuoLq2CYwJTBqQKBIXH+vPamom6CLFS8RCl8SGSKeQ==",
+      "version": "1.19.1",
+      "resolved": "https://npm.pkg.github.com/download/@redkubes/gitea-client-node/1.19.1/91f32e7ba2fd5919be4100f9697ba4947acbb44e",
+      "integrity": "sha512-qb+eLNOK8vSM/wctqV0WVBYnN0l7u9fu/F0jwL5X7sLGEFjSgOb+i5E8h1VoqnvNH1fLJ8M1OHQ/RLbG0cMbdQ==",
       "requires": {
         "bluebird": "^3.5.0",
         "request": "^2.81.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "9.0.6",
     "@kubernetes/client-node": "0.12.3",
-    "@redkubes/gitea-client-node": "1.16.6",
+    "@redkubes/gitea-client-node": "1.19.1",
     "@redkubes/harbor-client-node": "^2.2.1",
     "@redkubes/keycloak-client-node": "^15.0.0",
     "async-retry": "1.3.1",

--- a/src/tasks/gitea/gitea-drone-oauth.ts
+++ b/src/tasks/gitea/gitea-drone-oauth.ts
@@ -31,7 +31,12 @@ const auth = {
   username,
   password: env.GITEA_PASSWORD,
 }
-const oauthOpts = { ...new CreateOAuth2ApplicationOptions(), name: 'otomi-drone', redirectUris: [droneLoginUrl] }
+const oauthOpts = {
+  ...new CreateOAuth2ApplicationOptions(),
+  confidentialClient: true,
+  name: 'otomi-drone',
+  redirectUris: [droneLoginUrl],
+}
 
 export async function getGiteaAuthorizationHeaderCookies(oauthData: DroneSecret): Promise<string[]> {
   const options: AxiosRequestConfig = {


### PR DESCRIPTION
This PR is updating the gitea client to version 1.19.1 so it matches the current gitea version (see #[1096](https://github.com/redkubes/otomi-core/pull/1096))
This PR also solves bug #[1101](https://github.com/redkubes/otomi-core/issues/1101)