### PR TITLE
feat: changed ttl for keycloak access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,18 @@ This readme is aimed at development. If you wish to contribute please read our D
 ## Development
 
 Make sure your expected environment variables exist in a mandatory `.env` file (see `.env.sample`). 
+#
+**Important**
+When using `npm i` and you get the errors `Unauthorized` and `Permission denied` on the installation regarding getting packages from redkubes
+> Example: `npm ERR! 403 403 Forbidden - GET https://npm.pkg.github.com/redkubes/@redkubes%2fgitea-client-node - Permission denied`
 
+This can be fixed by adding the following line to the `.npmrc` file. 
+`//npm.pkg.github.com/:_authToken=PERSONAL_ACCESS_TOKEN_HERE`
+
+To create a personal access token, go to GitHub -> settings -> developer settings -> personal access token -> give read permission on packages and create the token
+
+**Remember not to push this token**
+#
 Then start a proxy to the api you wish to target:
 
 - drone: `k -n team-admin port-forward svc/drone 8081:80 &`

--- a/src/tasks/keycloak/keycloak.ts
+++ b/src/tasks/keycloak/keycloak.ts
@@ -102,6 +102,13 @@ async function main(): Promise<void> {
 
   // Create realm 'otomi'
   const realmConf = createRealm(keycloakRealm)
+  // token timeout in seconds
+  // 28800 = 8 hours
+  const tokenTimeout = 28800
+  realmConf.ssoSessionIdleTimeout = tokenTimeout
+  realmConf.ssoSessionMaxLifespan = tokenTimeout
+  realmConf.accessTokenLifespan = tokenTimeout
+  realmConf.accessTokenLifespanForImplicitFlow = tokenTimeout
   // the api does not offer a list method, and trying to get by id throws an error
   // which we wan to discard, so we run the next command with an empty errors array
   const existingRealm = (await doApiCall([], `Getting realm ${keycloakRealm}`, () =>

--- a/src/tasks/keycloak/keycloak.ts
+++ b/src/tasks/keycloak/keycloak.ts
@@ -32,6 +32,7 @@ import {
   KEYCLOAK_ADMIN,
   KEYCLOAK_ADMIN_PASSWORD,
   KEYCLOAK_REALM,
+  KEYCLOAK_TOKEN_TTL,
 } from '../../validators'
 import { keycloakRealm } from './config'
 import {
@@ -55,6 +56,7 @@ const env = cleanEnv({
   KEYCLOAK_ADDRESS,
   KEYCLOAK_ADDRESS_INTERNAL,
   KEYCLOAK_REALM,
+  KEYCLOAK_TOKEN_TTL,
   FEAT_EXTERNAL_IDP,
 })
 
@@ -102,13 +104,10 @@ async function main(): Promise<void> {
 
   // Create realm 'otomi'
   const realmConf = createRealm(keycloakRealm)
-  // token timeout in seconds
-  // 28800 = 8 hours
-  const tokenTimeout = 28800
-  realmConf.ssoSessionIdleTimeout = tokenTimeout
-  realmConf.ssoSessionMaxLifespan = tokenTimeout
-  realmConf.accessTokenLifespan = tokenTimeout
-  realmConf.accessTokenLifespanForImplicitFlow = tokenTimeout
+  realmConf.ssoSessionIdleTimeout = env.KEYCLOAK_TOKEN_TTL
+  realmConf.ssoSessionMaxLifespan = env.KEYCLOAK_TOKEN_TTL
+  realmConf.accessTokenLifespan = env.KEYCLOAK_TOKEN_TTL
+  realmConf.accessTokenLifespanForImplicitFlow = env.KEYCLOAK_TOKEN_TTL
   // the api does not offer a list method, and trying to get by id throws an error
   // which we wan to discard, so we run the next command with an empty errors array
   const existingRealm = (await doApiCall([], `Getting realm ${keycloakRealm}`, () =>

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -55,6 +55,10 @@ export const KEYCLOAK_CLIENT_ID = str({ desc: 'Default Keycloak Client', default
 export const KEYCLOAK_CLIENT_SECRET = str({ desc: 'The keycloak client secret' })
 export const KEYCLOAK_REALM = str({ desc: 'The Keycloak Realm', default: 'master' })
 export const KEYCLOAK_THEME_LOGIN = str({ desc: 'The Keycloak login theme', default: 'default' })
+export const KEYCLOAK_TOKEN_TTL = num({
+  desc: 'The Keycloak access token TTL in seconds, 28800 seconds = 8 hours',
+  default: 28800,
+})
 export const NODE_EXTRA_CA_CERTS = str({ default: undefined })
 export const NODE_TLS_REJECT_UNAUTHORIZED = bool({ default: true })
 export const OIDC_CLIENT_SECRET = str({ desc: 'The OIDC client secret used by keycloak to access the IDP' })


### PR DESCRIPTION
Ticket regarding this issue: https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/gh/redkubes/otomi-core/1093

This PR changes the keycloak Realm User access token to 8 hours. This is not a fix for the issue but it will mitigate the amount of times that people will come across the issue.