### PR TITLE
fix: update deprecated actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -70,10 +70,10 @@ jobs:
           echo changes=$changelog >> $GITHUB_OUTPUT
       - if: "contains(github.event.head_commit.message, 'chore(release)')"
         name: Create GitHub release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1.12.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.git_tag.outputs.tag }}
-          release_name: Release ${{ steps.git_tag.outputs.tag }}
+          tag: ${{ steps.git_tag.outputs.tag }}
+          name: Release ${{ steps.git_tag.outputs.tag }}
           body: ${{ steps.git_tag.outputs.changes }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,9 +31,9 @@ jobs:
           echo "Creating tag: $tag"
           echo "TAG=$tag" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: CI tests, image build and push tag to cache for main or branch
-        uses: whoan/docker-build-with-cache-action@v5
+        uses: whoan/docker-build-with-cache-action@v6
         with:
           username: redkubesbot
           password: '${{ secrets.NPM_TOKEN }}'

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,6 +12,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates some of the remaining deprecated GitHub Actions in Otomi-Tasks.

https://github.com/redkubes/otomi-core/issues/997

The Lint will still show a warning but that is because it doesn't use the newest version yet for this PR.