### PR TITLE
feat: otomi viewer rights

### DIFF
--- a/src/tasks/gitea/gitea.ts
+++ b/src/tasks/gitea/gitea.ts
@@ -9,7 +9,7 @@ import {
   Team,
 } from '@redkubes/gitea-client-node'
 import { doApiCall, waitTillAvailable } from '../../utils'
-import { cleanEnv, GITEA_PASSWORD, GITEA_URL, OTOMI_VALUES } from '../../validators'
+import { GITEA_PASSWORD, GITEA_URL, OTOMI_VALUES, cleanEnv } from '../../validators'
 import { orgName, otomiValuesRepoName, teamNameViewer, username } from '../common'
 
 const env = cleanEnv({
@@ -29,7 +29,7 @@ const readOnlyTeam: CreateTeamOption = {
   ...new CreateTeamOption(),
   canCreateOrgRepo: false,
   name: teamNameViewer,
-  includesAllRepositories: true,
+  includesAllRepositories: false,
   permission: CreateTeamOption.PermissionEnum.Read,
   units: ['repo.code'],
 }

--- a/src/tasks/gitea/gitea.ts
+++ b/src/tasks/gitea/gitea.ts
@@ -144,6 +144,14 @@ export default async function main(): Promise<void> {
   // create main org repo: otomi/values
   await upsertRepo(existingTeams, existingRepos, orgApi, repoApi, repoOption)
 
+  // add repo: otomi/values to the team: otomi-viewer
+  await doApiCall(
+    errors,
+    `Adding repo values to team otomi-viewer`,
+    () => repoApi.repoAddTeam(orgName, 'values', 'otomi-viewer'),
+    422,
+  )
+
   if (!hasArgo) return
 
   // then create initial gitops repo for teams


### PR DESCRIPTION
This PR changes the access rights of the Otomi-Viewer team.
Otomi-Viewer team no longer has read access for all repos.
Otomi-Viewer team only has read access to otomi/values repo.

[See issue](https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/gh/redkubes/unassigned-issues/674)