### PR TITLE
feat: gitea otomi charts repo

### DIFF
--- a/src/tasks/gitea/gitea.ts
+++ b/src/tasks/gitea/gitea.ts
@@ -143,7 +143,8 @@ export default async function main(): Promise<void> {
 
   // create main org repo: otomi/values
   await upsertRepo(existingTeams, existingRepos, orgApi, repoApi, repoOption)
-  await upsertRepo(existingTeams, existingRepos, orgApi, repoApi, { ...repoOption, name: 'otomi-charts' })
+  // create otomi/charts repo for auto image updates
+  await upsertRepo(existingTeams, existingRepos, orgApi, repoApi, { ...repoOption, name: 'charts' })
 
   // add repo: otomi/values to the team: otomi-viewer
   await doApiCall(

--- a/src/tasks/gitea/gitea.ts
+++ b/src/tasks/gitea/gitea.ts
@@ -143,6 +143,7 @@ export default async function main(): Promise<void> {
 
   // create main org repo: otomi/values
   await upsertRepo(existingTeams, existingRepos, orgApi, repoApi, repoOption)
+  await upsertRepo(existingTeams, existingRepos, orgApi, repoApi, {...repoOption, name: 'otomi-charts'})
 
   // add repo: otomi/values to the team: otomi-viewer
   await doApiCall(

--- a/src/tasks/gitea/gitea.ts
+++ b/src/tasks/gitea/gitea.ts
@@ -143,7 +143,7 @@ export default async function main(): Promise<void> {
 
   // create main org repo: otomi/values
   await upsertRepo(existingTeams, existingRepos, orgApi, repoApi, repoOption)
-  await upsertRepo(existingTeams, existingRepos, orgApi, repoApi, {...repoOption, name: 'otomi-charts'})
+  await upsertRepo(existingTeams, existingRepos, orgApi, repoApi, { ...repoOption, name: 'otomi-charts' })
 
   // add repo: otomi/values to the team: otomi-viewer
   await doApiCall(


### PR DESCRIPTION
### Implements:
https://app.zenhub.com/workspaces/dev-5e7e84dddc966f05a627a19b/issues/gh/redkubes/unassigned-issues/654

### Description:
This PR adds a feature to create gitea otomi charts repository.
Is paired with: https://github.com/redkubes/otomi-core/pull/1333

### Changes Made:
Added upsertRepo function call to create gitea otomi charts repository