### PR TITLE
fix: set the offline session to seven days

### DIFF
--- a/src/tasks/keycloak/keycloak.ts
+++ b/src/tasks/keycloak/keycloak.ts
@@ -32,6 +32,8 @@ import {
   KEYCLOAK_ADMIN,
   KEYCLOAK_ADMIN_PASSWORD,
   KEYCLOAK_REALM,
+  KEYCLOAK_TOKEN_OFFLINE_MAX_TTL_ENABLED,
+  KEYCLOAK_TOKEN_OFFLINE_TTL,
   KEYCLOAK_TOKEN_TTL,
   WAIT_OPTIONS,
 } from '../../validators'
@@ -58,6 +60,8 @@ const env = cleanEnv({
   KEYCLOAK_ADDRESS_INTERNAL,
   KEYCLOAK_REALM,
   KEYCLOAK_TOKEN_TTL,
+  KEYCLOAK_TOKEN_OFFLINE_TTL,
+  KEYCLOAK_TOKEN_OFFLINE_MAX_TTL_ENABLED,
   FEAT_EXTERNAL_IDP,
   WAIT_OPTIONS,
 })
@@ -110,6 +114,9 @@ async function main(): Promise<void> {
   realmConf.ssoSessionMaxLifespan = env.KEYCLOAK_TOKEN_TTL
   realmConf.accessTokenLifespan = env.KEYCLOAK_TOKEN_TTL
   realmConf.accessTokenLifespanForImplicitFlow = env.KEYCLOAK_TOKEN_TTL
+  realmConf.offlineSessionMaxLifespanEnabled = env.KEYCLOAK_TOKEN_OFFLINE_MAX_TTL_ENABLED
+  realmConf.offlineSessionIdleTimeout = env.KEYCLOAK_TOKEN_OFFLINE_TTL
+  realmConf.offlineSessionMaxLifespan = env.KEYCLOAK_TOKEN_OFFLINE_TTL
   // the api does not offer a list method, and trying to get by id throws an error
   // which we wan to discard, so we run the next command with an empty errors array
   const existingRealm = (await doApiCall([], `Getting realm ${keycloakRealm}`, () =>

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -65,7 +65,7 @@ export const KEYCLOAK_TOKEN_OFFLINE_TTL = num({
 })
 export const KEYCLOAK_TOKEN_OFFLINE_MAX_TTL_ENABLED = bool({
   desc: 'Allows the Keycloak access token TTL to have max limit for offline use',
-  default: false,
+  default: true,
 })
 export const NODE_EXTRA_CA_CERTS = str({ default: undefined })
 export const NODE_TLS_REJECT_UNAUTHORIZED = bool({ default: true })

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -59,6 +59,14 @@ export const KEYCLOAK_TOKEN_TTL = num({
   desc: 'The Keycloak access token TTL in seconds, 28800 seconds = 8 hours',
   default: 28800,
 })
+export const KEYCLOAK_TOKEN_OFFLINE_TTL = num({
+  desc: 'The Keycloak offline access token TTL in seconds, 604800 seconds = 7 days',
+  default: 604800,
+})
+export const KEYCLOAK_TOKEN_OFFLINE_MAX_TTL_ENABLED = bool({
+  desc: 'Allows the Keycloak access token TTL to have max limit for offline use',
+  default: false,
+})
 export const NODE_EXTRA_CA_CERTS = str({ default: undefined })
 export const NODE_TLS_REJECT_UNAUTHORIZED = bool({ default: true })
 export const OIDC_CLIENT_SECRET = str({ desc: 'The OIDC client secret used by keycloak to access the IDP' })


### PR DESCRIPTION
This PR sets the offline keycloak token to 7 days.

<img width="583" alt="image" src="https://github.com/redkubes/otomi-tasks/assets/18527012/6ac84ed6-c2a9-48c3-aa25-76438730e53d">
